### PR TITLE
Updated hyperparameter policy

### DIFF
--- a/training_rules.adoc
+++ b/training_rules.adoc
@@ -234,7 +234,14 @@ OPEN: Frameworks are free to alter the graph.
 == Training Loop
 
 === Hyperparameters
-Hyperparameters (e.g. batch size, learning rate) may be selected to best utilize the framework and system being tested. 
+An arbitrary batch size may be chosen to allow for tailoring the application to the hardware platform’s memory hierarchy. The batch size must be constant for the entire run, with the exception of the final batch in each epoch which may be smaller to account for the remainder when the number of samples is divided by batch.
+
+By default, the only other hyperparameter that may vary is learning rate, because learning rate needs to change to accommodate the change in batch size or different precision. The learning rate schedule is defined relative to the reference implementation using four parameters wb, wr, t, and r:
+- A linear warm-up period of wb batches may be added with a per batch step size wr. It is assumed that the reference implementation learning rate is a constant r0 for more than wb batches. Then the warm up learning rate for batch b is r0 - (wb - b) * wr. The term wr is contrained to be (r0 / (wb * 2^wk)) where wk is a non-negative integer.
+- The learning rate schedule may be scaled in time by multiplying the input epoch by a constant factor t and rounding down, where t is constrained to be (1 + tk/10) where tk is a positive integer.
+- The learning rate may be scaled by a constant factor r, where r is an integer.
+
+Some benchmarks may require extensions of this policy; submitters are encouraged to request extensions based on data.
 
 === Loss function 
 CLOSED: The same loss function used in the reference implementation must be used.

--- a/training_rules.adoc
+++ b/training_rules.adoc
@@ -234,9 +234,11 @@ OPEN: Frameworks are free to alter the graph.
 == Training Loop
 
 === Hyperparameters
+By default, hyperparameters may not be changed. Hyperparameters include regularization terms such as norms and weight decays.
+
 An arbitrary batch size may be chosen to allow for tailoring the application to the hardware platform’s memory hierarchy. The batch size must be constant for the entire run, with the exception of the final batch in each epoch which may be smaller to account for the remainder when the number of samples is divided by batch.
 
-By default, the only other hyperparameter that may vary is learning rate, because learning rate needs to change to accommodate the change in batch size or different precision. The learning rate schedule is defined relative to the reference implementation using four parameters wb, wr, t, and r:
+Learning rate may be changed to accommodate the change in batch size or different precision. The learning rate schedule is defined relative to the reference implementation using four parameters wb, wr, t, and r:
 - A linear warm-up period of wb batches may be added with a per batch step size wr. It is assumed that the reference implementation learning rate is a constant r0 for more than wb batches. Then the warm up learning rate for batch b is r0 - (wb - b) * wr. The term wr is contrained to be (r0 / (wb * 2^wk)) where wk is a non-negative integer.
 - The learning rate schedule may be scaled in time by multiplying the input epoch by a constant factor t and rounding down, where t is constrained to be (1 + tk/10) where tk is a positive integer.
 - The learning rate may be scaled by a constant factor r, where r is an integer.


### PR DESCRIPTION
Adapted from: https://docs.google.com/document/d/1oJfVM4_XGlpBUjUpqELauprgt9Ov-693kW1rYmaYrco/edit?ts=5b6b43e8 for basis. Removed mention of shard size, identified by WG as confusing. Otherwise, unchanged except for conversion to third person for consistency. Fixes #66. Fixes #54. Fixes #68.