### PR TITLE
Typos in model equivalence

### DIFF
--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -414,7 +414,7 @@ All implementations are allowed as long as the latency and accuracy bounds are
 met and the reference weights are used. Reference weights may be modified
 according to the quantization rules.
 
-Examples of illegal variance in implementations include, but are not limited to:
+Examples of legal variance in implementations include, but are not limited to:
 
 * Arbitrary frameworks and runtimes: TensorFlow, TensorFlow-lite, ONNX, PyTorch,
   etc, provided they conform to the rest of the rules
@@ -454,7 +454,7 @@ Examples of illegal variance in implementations include, but are not limited to:
 For anything else you want on this list contact submitters five weeks prior to
 the submission deadline.
 
-Examples of legal variance in implementations include, but are not limited to:
+Examples of illegal variance in implementations include, but are not limited to:
 
 * Wholesale weight replacement or supplements
 


### PR DESCRIPTION
First list (line 417) was 'illegal' --> legal
Second list (line 457) was 'legal' --> illegal