### PR TITLE
Epoch numbering from 1

### DIFF
--- a/training_rules.adoc
+++ b/training_rules.adoc
@@ -179,7 +179,7 @@ CLOSED: The numerical formats fp64, fp32, fp16, and bfloat16 are pre-approved fo
 OPEN: Any format and scaling may be used.
 
 === Epoch numbering
-Epochs should always be numbered from 0.
+Epochs should always be numbered from 1.
 
 === Result rounding
 Public results should be rounded normally.


### PR DESCRIPTION
According to the last logging spec:
>epoch_start
>Metadata:
>“epoch_num”: (epoch number starting from 1)
https://docs.google.com/document/d/1u15ouRbvd2xZkMEHNtmtg-yGzw0Zs6KVxQG_5WjTz7o/edit#