### PR TITLE
Updating allowed optimizer table to match analysis

### DIFF
--- a/training_rules.adoc
+++ b/training_rules.adoc
@@ -363,9 +363,13 @@ Analysis to support this can be found in the document "MLPerf Optimizer Review" 
 |===
 | Benchmark | Algorithm | Framework | Allowed Optimizer
 
-| RN50 | SGD with Momentum & LARS | PyTorch	| ?	
-|      |                          |	TensorFlow | ?	
+| RN50 | LARS                     | PyTorch	| [No compliant implementation]	
+|      |                          |	TensorFlow | MLPERF_LARSOptimizer	
 |      |                          | MxNet | SGDwFASTLARS
+| RN50 | SGD with Momentum        | PyTorch	| apex.optimizers.FusedSGD	
+|      |                          |	PyTorch | torch.optim.SGD	
+|      |                          |	TensorFlow | tf.train.MomentumOptimizer	
+|      |                          | MxNet | [No compliant implementation]
 | Minigo| SGD with Momentum	      | PyTorch | apex.optimizers.FusedSGD	
 |      |                          | PyTorch | torch.optim.SGD	
 |      |                          | TensorFlow | tf.train.MomentumOptimizer	
@@ -383,3 +387,8 @@ Analysis to support this can be found in the document "MLPerf Optimizer Review" 
 |      |                          | TensorFlow | tf.train.AdamOptimizer	
 |      | Lazy Adam	              | PyTorch	| torch.optim.sparse_adam	
 |      |                          | TensorFlow | tf.contrib.opt.LazyAdamOptimizer	
+| BERT | LAMB             	      | PyTorch	| apex.optimizers.FusedLAMB
+|      |              	          | TensorFlow	| tf.optimizers.LAMB
+| DLRM | SGD             	        | PyTorch	| torch.optim.SGD
+|      |              	          | TensorFlow	| tf.train.MomentumOptimizer
+


### PR DESCRIPTION
Added BERT, DLRM, split RN50 SGD from RN50 LARS, and added not that there are no compliant RN50 LARS implementations in PyTorch and no compliant RN50 SGD implementations in MxNet.

See: https://github.com/mlperf/training_policies/issues/318