### PR TITLE
Update HPC rules

### DIFF
--- a/hpc_training_rules.adoc
+++ b/hpc_training_rules.adoc
@@ -26,7 +26,7 @@ The benchmark suite consists of the benchmarks shown in the following table.
 |===
 |Problem |Dataset |Quality Target
 |Climate segmentation |CAM5+TECA climate simulation with 3 target classes (atmospheric river, tropical cyclone, background) |IOU 0.82 (could be adjusted if training times are too long)
-|Cosmological parameter prediction |CosmoFlow N-body cosmological simulation data with 4 cosmological parameter targets |Mean average error 0.128
+|Cosmological parameter prediction |CosmoFlow N-body cosmological simulation data with 4 cosmological parameter targets |Mean average error 0.124
 |===
 
 == Divisions
@@ -75,4 +75,10 @@ You are encouraged to also report the additional metrics of the benchmark descri
 
 == Benchmark Results
 
-We following the specified training rules except all benchmarks are run 5 times.
+We follow the MLPerf Training Rule 11 along with the following required number of runs per benchmark.
+
+|===
+|Benchmark |Number of Runs
+|DeepCAM | 5
+|CosmoFlow | 10
+|===

--- a/hpc_training_rules.adoc
+++ b/hpc_training_rules.adoc
@@ -55,7 +55,7 @@ The data at the start of the benchmark run should reside on a parallel file syst
 
 You must flush/reset the on-node caches prior to benchmarking. Due to practicality issues, you are not required to reset off-node system-level caches.
 
-We otherwise follow the training rule on consistency with the reference implementation preprocessing.
+We otherwise follow the training rule on consistency with the reference implementation preprocessing and allowance for reformatting.
 
 == Training Loop
 

--- a/hpc_training_rules.adoc
+++ b/hpc_training_rules.adoc
@@ -25,7 +25,7 @@ The benchmark suite consists of the benchmarks shown in the following table.
 
 |===
 |Problem |Dataset |Quality Target
-|Climate segmentation |CAM5+TECA climate simulation with 3 target classes (atmospheric river, tropical cyclone, background) |IOU 0.82 (could be adjusted if training times are too long)
+|Climate segmentation |CAM5+TECA climate simulation with 3 target classes (atmospheric river, tropical cyclone, background) |IOU 0.82
 |Cosmological parameter prediction |CosmoFlow N-body cosmological simulation data with 4 cosmological parameter targets |Mean average error 0.124
 |===
 


### PR DESCRIPTION
Updating CosmoFlow target and number of runs.

Clarifying rule on data state at start of run to explicitly mention consistency with Training rule allowance on data reformatting.

Note: CLA signing is in progress. If that's an obstacle, perhaps @TheKanter could do this for me.