### PR TITLE
HPC v0.7 rules updates

### DIFF
--- a/hpc_training_rules.adoc
+++ b/hpc_training_rules.adoc
@@ -26,7 +26,7 @@ The benchmark suite consists of the benchmarks shown in the following table.
 |===
 |Problem |Dataset |Quality Target
 |Climate segmentation |CAM5+TECA climate simulation with 3 target classes (atmospheric river, tropical cyclone, background) |IOU 0.82 (could be adjusted if training times are too long)
-|Cosmological parameter prediction |CosmoFlow N-body cosmological simulation data with 4 cosmological parameter targets |Mean average error 0.128
+|Cosmological parameter prediction |CosmoFlow N-body cosmological simulation data with 4 cosmological parameter targets |Mean average error 0.124
 |===
 
 == Divisions
@@ -75,4 +75,10 @@ You are encouraged to also report the additional metrics of the benchmark descri
 
 == Benchmark Results
 
-We following the specified training rules except all benchmarks are run 5 times.
+We follow the MLPerf Training Rule 11 along with the following required number of runs per benchmark.
+
+|===
+|Benchmark |Number of Runs
+|DeepCAM | 5
+|CosmoFlow | 10
+|===

--- a/hpc_training_rules.adoc
+++ b/hpc_training_rules.adoc
@@ -75,17 +75,17 @@ Allowed hyperparameter and optimizer settings will be specified in the MLPerf HP
  |CosmoFlow |opt_learning_rate_warmup_factor |unconstrained |the constant factor applied at learning rate warm up |scaled learning rate / `base_lr`
  |CosmoFlow |opt_learning_rate_decay_boundary_epochs |[i, j], where i, j are positive integers, i.e. two learning rate decays are allowed in training" |Epochs at which learning rate decays |link:https://github.com/sparticlesteve/cosmoflow-benchmark/blob/57c2454a28e415ca7df0135f016297763f6e4946/configs/cosmo.yaml#L51[config]
  |CosmoFlow |opt_learning_rate_decay_factor |`0 < value < 1`, and you may use a different value for each decay |the learning rate decay factor(s) at the decay boundary epochs |link:https://github.com/sparticlesteve/cosmoflow-benchmark/blob/57c2454a28e415ca7df0135f016297763f6e4946/configs/cosmo.yaml#L51[config]
- |DeepCAM |global_batch_size |unconstrained |the global batch size for training |
- |DeepCAM |opt_name |AdamW or LAMB |the optimizer name |
- |DeepCAM |opt_epsilon |1e-6 or 1e-8 |epsilon for Adam |
- |DeepCAM |opt_base_learning_rate |unconstrained |the base learning rate |
- |DeepCAM |opt_learning_rate_warmup_steps |unconstrained |the number of epochs for learning rate to warm up to base value |
- |DeepCAM |opt_learning_rate_warmup_factor |unconstrained |the constant factor applied at learning rate warmup |
- |DeepCAM |opt_learning_rate_decay_steps |unconstrained |the steps at which learning rate is decayed |
- |DeepCAM |opt_learning_rate_decay_factor |unconstrained |the learning rate decay factor |
- |DeepCAM |opt_weight_decay |0.01 |L2 weight decay |
- |DeepCAM |validation_frequency |100 |number of steps between model validation |
- |DeepCAM |loss_weight_pow |-0.125 |negative loss weight |
+ |DeepCAM |global_batch_size |unconstrained |the global batch size for training |`--local_batch_size` times number of workers
+ |DeepCAM |opt_name |AdamW or LAMB |the optimizer name |`--optimizer`
+ |DeepCAM |opt_epsilon |1e-6 or 1e-8 |epsilon for Adam |`--adam_eps`
+ |DeepCAM |opt_base_learning_rate |unconstrained |the base learning rate |`--start_lr` times warmup factor
+ |DeepCAM |opt_learning_rate_warmup_steps |unconstrained |the number of epochs for learning rate to warm up to base value |`--lr_warmup_steps`
+ |DeepCAM |opt_learning_rate_warmup_factor |unconstrained |the constant factor applied at learning rate warmup |`--lr_warmup_factor`
+ |DeepCAM |opt_learning_rate_decay_steps |unconstrained |the steps at which learning rate is decayed |milestones in `--lr_schedule type="multistep",milestones="3000 10000",decay_rate="0.1"`
+ |DeepCAM |opt_learning_rate_decay_factor |unconstrained |the learning rate decay factor |decay_rate in `--lr_schedule type="multistep",milestones="15000 25000",decay_rate="0.1"`
+ |DeepCAM |opt_weight_decay |0.01 |L2 weight decay |`--weight_decay`
+ |DeepCAM |validation_frequency |100 |number of steps between model validation |`--validation_frequency`
+ |DeepCAM |loss_weight_pow |-0.125 |negative loss weight |`--loss_weight_pow`
 |===
 
 OPEN: Hyperparameters and optimizer may be freely changed.

--- a/hpc_training_rules.adoc
+++ b/hpc_training_rules.adoc
@@ -55,7 +55,7 @@ The data at the start of the benchmark run should reside on a parallel file syst
 
 You must flush/reset the on-node caches prior to benchmarking. Due to practicality issues, you are not required to reset off-node system-level caches.
 
-We otherwise follow the training rule on consistency with the reference implementation preprocessing.
+We otherwise follow the training rule on consistency with the reference implementation preprocessing and allowance for reformatting.
 
 == Training Loop
 

--- a/hpc_training_rules.adoc
+++ b/hpc_training_rules.adoc
@@ -25,7 +25,7 @@ The benchmark suite consists of the benchmarks shown in the following table.
 
 |===
 |Problem |Dataset |Quality Target
-|Climate segmentation |CAM5+TECA climate simulation with 3 target classes (atmospheric river, tropical cyclone, background) |IOU 0.82 (could be adjusted if training times are too long)
+|Climate segmentation |CAM5+TECA climate simulation with 3 target classes (atmospheric river, tropical cyclone, background) |IOU 0.82
 |Cosmological parameter prediction |CosmoFlow N-body cosmological simulation data with 4 cosmological parameter targets |Mean average error 0.124
 |===
 

--- a/hpc_training_rules.adoc
+++ b/hpc_training_rules.adoc
@@ -65,6 +65,28 @@ CLOSED:
 
 Allowed hyperparameter and optimizer settings will be specified in the MLPerf HPC v0.5 Hyperparameter List. https://docs.google.com/spreadsheets/d/1jxsas4RRxKoKmIYcFZcFCQ1ZLnaMLSU8B5g5ZDKQ7sE/edit?usp=sharing
 
+|===
+ |Model |Name |Constraint |Definition |Reference Code
+ |CosmoFlow |global_batch_size |unconstrained |The global batch size for training |
+ |CosmoFlow |opt_name |"sgd" |The optimizer name |
+ |CosmoFlow |opt_base_learning_rate |unconstrained |The base learning rate |
+ |CosmoFlow |opt_learning_rate_warmup_epochs |unconstrained |the number of epochs for learning rate to warm up to base value |
+ |CosmoFlow |opt_learning_rate_warmup_factor |unconstrained |the constant factor applied at learning rate warm up |
+ |CosmoFlow |opt_learning_rate_decay_boundary_epochs |[i, j], where i, j are positive integers, i.e. two learning rate decays are allowed in training" |Epochs at which learning rate decays |
+ |CosmoFlow |opt_learning_rate_decay_factor |`0 < value < 1`, and you may use a different value for each decay |the learning rate decay factor(s) at the decay boundary epochs |
+ |DeepCAM |global_batch_size |unconstrained |the global batch size for training |
+ |DeepCAM |opt_name |AdamW or LAMB |the optimizer name |
+ |DeepCAM |opt_epsilon |1e-6 or 1e-8 |epsilon for Adam |
+ |DeepCAM |opt_base_learning_rate |unconstrained |The base learning rate |
+ |DeepCAM |opt_learning_rate_warmup_steps |unconstrained |the number of epochs for learning rate to warm up to base value |
+ |DeepCAM |opt_learning_rate_warmup_factor |unconstrained |the constant factor applied at learning rate warmup |
+ |DeepCAM |opt_learning_rate_decay_steps |unconstrained |the steps at which learning rate is decayed |
+ |DeepCAM |opt_learning_rate_decay_factor |unconstrained |the learning rate decay factor |
+ |DeepCAM |opt_weight_decay |0.01 |L2 weight decay |
+ |DeepCAM |validation_frequency |100 |number of steps between model validation |
+ |DeepCAM |loss_weight_pow |-0.125 |negative loss weight |
+|===
+
 OPEN: Hyperparameters and optimizer may be freely changed.
 
 == Run Results

--- a/hpc_training_rules.adoc
+++ b/hpc_training_rules.adoc
@@ -67,17 +67,18 @@ Allowed hyperparameter and optimizer settings will be specified in the MLPerf HP
 
 |===
  |Model |Name |Constraint |Definition |Reference Code
- |CosmoFlow |global_batch_size |unconstrained |The global batch size for training |
- |CosmoFlow |opt_name |"sgd" |The optimizer name |
- |CosmoFlow |opt_base_learning_rate |unconstrained |The base learning rate |
- |CosmoFlow |opt_learning_rate_warmup_epochs |unconstrained |the number of epochs for learning rate to warm up to base value |
- |CosmoFlow |opt_learning_rate_warmup_factor |unconstrained |the constant factor applied at learning rate warm up |
- |CosmoFlow |opt_learning_rate_decay_boundary_epochs |[i, j], where i, j are positive integers, i.e. two learning rate decays are allowed in training" |Epochs at which learning rate decays |
- |CosmoFlow |opt_learning_rate_decay_factor |`0 < value < 1`, and you may use a different value for each decay |the learning rate decay factor(s) at the decay boundary epochs |
+ |CosmoFlow |global_batch_size |unconstrained |the global batch size for training |local `batch_size` (`--batch-size`) times number of workers. Baseline config is 64
+ |CosmoFlow |opt_name |"sgd" |the optimizer name |`--optimizer` or link:https://github.com/sparticlesteve/cosmoflow-benchmark/blob/57c2454a28e415ca7df0135f016297763f6e4946/configs/cosmo.yaml#L33[config]
+ |CosmoFlow |sgd_opt_momentum |0.9 |SGD momentum |link:https://github.com/sparticlesteve/cosmoflow-benchmark/blob/57c2454a28e415ca7df0135f016297763f6e4946/configs/cosmo.yaml#L34[config]
+ |CosmoFlow |opt_base_learning_rate |unconstrained |The base learning rate |`base_lr` times scaling factor, e.g. `global_batch_size/base_batch_size` if scaling="linear". link:https://github.com/sparticlesteve/cosmoflow-benchmark/blob/57c2454a28e415ca7df0135f016297763f6e4946/configs/cosmo.yaml#L38[Config]
+ |CosmoFlow |opt_learning_rate_warmup_epochs |unconstrained |the number of epochs for learning rate to warm up to base value |link:https://github.com/sparticlesteve/cosmoflow-benchmark/blob/57c2454a28e415ca7df0135f016297763f6e4946/configs/cosmo.yaml#L47[config]
+ |CosmoFlow |opt_learning_rate_warmup_factor |unconstrained |the constant factor applied at learning rate warm up |scaled learning rate / `base_lr`
+ |CosmoFlow |opt_learning_rate_decay_boundary_epochs |[i, j], where i, j are positive integers, i.e. two learning rate decays are allowed in training" |Epochs at which learning rate decays |link:https://github.com/sparticlesteve/cosmoflow-benchmark/blob/57c2454a28e415ca7df0135f016297763f6e4946/configs/cosmo.yaml#L51[config]
+ |CosmoFlow |opt_learning_rate_decay_factor |`0 < value < 1`, and you may use a different value for each decay |the learning rate decay factor(s) at the decay boundary epochs |link:https://github.com/sparticlesteve/cosmoflow-benchmark/blob/57c2454a28e415ca7df0135f016297763f6e4946/configs/cosmo.yaml#L51[config]
  |DeepCAM |global_batch_size |unconstrained |the global batch size for training |
  |DeepCAM |opt_name |AdamW or LAMB |the optimizer name |
  |DeepCAM |opt_epsilon |1e-6 or 1e-8 |epsilon for Adam |
- |DeepCAM |opt_base_learning_rate |unconstrained |The base learning rate |
+ |DeepCAM |opt_base_learning_rate |unconstrained |the base learning rate |
  |DeepCAM |opt_learning_rate_warmup_steps |unconstrained |the number of epochs for learning rate to warm up to base value |
  |DeepCAM |opt_learning_rate_warmup_factor |unconstrained |the constant factor applied at learning rate warmup |
  |DeepCAM |opt_learning_rate_decay_steps |unconstrained |the steps at which learning rate is decayed |


### PR DESCRIPTION
This includes our final rules doc for HPC v0.7.

- updated cosmoflow target
- hyperparameter table
- number of runs per benchmark
- minor text updates