### PR TITLE
Add a rule about DLRM training data shuffling

### DIFF
--- a/training_rules.adoc
+++ b/training_rules.adoc
@@ -224,6 +224,8 @@ CLOSED: the training and test data must be traversed in the same conceptual orde
 
 Where data pipelines randomly order data, arbitrary sharding, batching, and packing are allowed provided that (1) the data is still overall randomly ordered and not ordered to improve convergence and (2) each datum still appears exactly once.
 
+For DLRM the submissions are allowed to use a preshuffled dataset and are not obligated to shuffle the data once more during training. However, the reference implementation uses both preshuffled data and an approximate "batch shuffle" performed on-the-fly. Reference runs should also use a different seed in each run, so that the order of the training batches in each reference run is different. Even though the submissions are allowed to not shuffle the data on-the-fly, they are obligated to match the convergence behavior of the reference which does perform on-the-fly "batch-shuffle". Using a preshuffled dataset with a hand-crafted, advantageous data ordering is disallowed.
+
 OPEN: The training data may be traversed in any order. The test data must be traversed in the same order as the reference implementation.
 
 == RL Environment


### PR DESCRIPTION
Shuffling rules about DLRM were not clear enough in the v0.7 round and they left a lot of room for interpretation. This update makes a clear rule that is easy to follow and should not impact convergence or performance of DLRM implementations.

This was actually part of https://github.com/mlcommons/training_policies/pull/411, which we discussed, but I mistakenly closed that thinking it was only about packing, which we no longer are using that PR for.  This is cleaner to break out data shuffling into its own PR, anyway.