### PR TITLE
fix missing Table-close markup on the allowed-optimizer table

### DIFF
--- a/training_rules.adoc
+++ b/training_rules.adoc
@@ -541,6 +541,7 @@ TODO: locate the document and provide working link
 | Image segmentation (medical) | SGD with Momentum      | PyTorch	    | torch.optim.SGD
 |      |              	          | TensorFlow	| tf.train.MomentumOptimizer
 |      |              	          | MXNet	    | mx.optimizer.NAG
+|===
 
 == Appendix: v1.0 Specific Rules
 


### PR DESCRIPTION
My apologies, in commit 6b5e7131 I left out the markup to close the table in Appendix 15.  So currently all of what is supposed to be Appendix 16 is incorrectly formatted into the last column of the table from Appendix 15.

This is a one line fix that simply adds the markup to close the table and fix the formatting error I introduced in 6b5e7131.
