### PR TITLE
Submissions should use full vocab size.

### DIFF
--- a/training_rules.adoc
+++ b/training_rules.adoc
@@ -200,6 +200,8 @@ CLOSED: For benchmarks with sequence inputs, you may choose a length N and eithe
 
 CLOSED: Two ways to represent the Mask R-CNN mask are permitted. One is a polygon and the other is a scalable bitmask. 
 
+CLOSED: For benchmarks which use a language vocabulary, submissions should use the full vocabulary as used by reference. Mathematically equivalent padding of vocabulary size is allowed.
+
 OPEN: The closed division data representations restrictions only apply at the start of the run. Data may be represented in an arbitrary fashion during the run.
 
 === Other Uses of Data

--- a/training_rules.adoc
+++ b/training_rules.adoc
@@ -200,7 +200,7 @@ CLOSED: For benchmarks with sequence inputs, you may choose a length N and eithe
 
 CLOSED: Two ways to represent the Mask R-CNN mask are permitted. One is a polygon and the other is a scalable bitmask. 
 
-CLOSED: For benchmarks which use a language vocabulary, submissions should use the full vocabulary as used by reference. Mathematically equivalent padding of vocabulary size is allowed.
+CLOSED: For benchmarks which use language vocabulary, submissions should use the full vocabulary as used by reference. Mathematically equivalent padding of vocabulary size is allowed.
 
 OPEN: The closed division data representations restrictions only apply at the start of the run. Data may be represented in an arbitrary fashion during the run.
 


### PR DESCRIPTION
Submissions should not drop UNUSED tokens from vocabulary as this can cause a mathematical difference in how often MASK predictions hit <UNUSED> as compared to that in reference implementation.
