### PR TITLE
Results with matching seeds should be pruned

### DIFF
--- a/hpc_training_rules.adoc
+++ b/hpc_training_rules.adoc
@@ -143,6 +143,7 @@ It is not allowed to merge logging files for individual instances.
 
 Restrictions: 
 
+* Due to large number of simultaneously-trained instances it's possible that some random seeds will match. Runs with identical seeds must be pruned from final results. Submitters can avoid issue by choosing non-matching seeds for their runs. 
 * The submitter *must not report this score on its own*. It has to be reported in conjunction with at least one score from <<Strong Scaling (Time to Convergence)>> from the same benchmark.
 * this score *does not allow for extrapolation*. All reported M' training instances must have converged and it is not allowed to extrapolate results in S or T.
 


### PR DESCRIPTION
This PR defines what happens when two or more models use the same (randomly chosen) seed. Problem is most likely to happen in weak scaling results due to the large number of simultaneously trained models. This was a point of discussion during the MLPerf HPC v0.7 review round.