### PR TITLE
[MLPerfHPC] Re-submissions due to hardware failures

### DIFF
--- a/hpc_training_rules.adoc
+++ b/hpc_training_rules.adoc
@@ -145,7 +145,7 @@ Restrictions:
 
 * The submitter *must not report this score on its own*. It has to be reported in conjunction with at least one score from <<Strong Scaling (Time to Convergence)>> from the same benchmark.
 * this score *does not allow for extrapolation*. All reported M' training instances must have converged and it is not allowed to extrapolate results in S or T.
-
+* Due to large scale of weakly-scaled submissions, it's possible that hardware failures can occur during training. Although unfortunate, this issue is not a sufficient reason to request a post-deadline re-run and re-submission. Submitters are responsible to plan ahead and give themselves enough time to overcome any challenges that may cause them to miss the submission deadline.
 
 == Benchmark Results
 


### PR DESCRIPTION
This PR defines what happens when hardware failures cause a weakly-scaled run to miss the submission deadline. This was a point of discussion during the MLPerf HPC v0.7 review meetings.