### PR TITLE
[HPC] Fix reference model links in hpc_training_rules

### DIFF
--- a/hpc_training_rules.adoc
+++ b/hpc_training_rules.adoc
@@ -42,9 +42,9 @@ The closed division models are:
 
 |===
 |Problem |Model
-|Climate segmentation  |https://github.com/azrael417/mlperf-deepcam
-|Cosmological parameter prediction |https://github.com/sparticlesteve/cosmoflow-benchmark
-|Modeling catalysts |https://github.com/sparticlesteve/ocp/tree/mlperf-hpc-reference
+|Climate segmentation  |https://github.com/mlcommons/hpc/tree/main/deepcam
+|Cosmological parameter prediction |https://github.com/mlcommons/hpc/tree/main/cosmoflow
+|Modeling catalysts |https://github.com/mlcommons/hpc/tree/main/open_catalyst
 |===
 
 == Data Set


### PR DESCRIPTION
Fixes #492 

Simply updates the table of reference model links to correctly point to the reference repository rather than the old external repositories.