### PR TITLE
Update hpc_training_rules.adoc

### DIFF
--- a/hpc_training_rules.adoc
+++ b/hpc_training_rules.adoc
@@ -9,11 +9,11 @@
 Version 2.0: 
 August 22, 2022
 
-Points of contact: David Kanter (dkanter@gmail.com), Steve Farrell (sfarrell@lbl.gov)
+Points of contact: David Kanter (dkanter@gmail.com), Steve Farrell (sfarrell@lbl.gov), Murali Emani (memani@anl.gov)
 
 == Overview
-2
-All rules are taken from the MLPerf Training Rules, the version at the time of HPC rules freeze, https://github.com/mlcommons/training_policies/commit/5a910009c991cb3b98448c9baf60b7ba018c3c06 except for those that are overridden here.
+
+All rules are taken from the MLPerf Training Rules, the version at the time of HPC rules freeze, (https://github.com/mlcommons/training_policies/commit/5a910009c991cb3b98448c9baf60b7ba018c3c06) except for those that are overridden here.
 
 The MLPerf name and logo are trademarks. In order to refer to a result using the
 MLPerf name, the result must conform to the letter and spirit of the rules

--- a/hpc_training_rules.adoc
+++ b/hpc_training_rules.adoc
@@ -12,7 +12,7 @@ Points of contact: David Kanter (dkanter@gmail.com), Steve Farrell (sfarrell@lbl
 
 == Overview
 
-All rules are taken from the MLPerf Training Rules except for those that are overridden here.
+All rules are taken from the MLPerf Training Rules (the version at the time of HPC rules freeze) except for those that are overridden here. 
 
 The MLPerf name and logo are trademarks. In order to refer to a result using the
 MLPerf name, the result must conform to the letter and spirit of the rules

--- a/hpc_training_rules.adoc
+++ b/hpc_training_rules.adoc
@@ -4,15 +4,16 @@
 :sectnums:
 
 = MLPerf HPC Training Rules
+<!-- Version 0.7  July 16, 2020 -->
 
-Version 0.7 
-July 16, 2020
+Version 2.0: 
+August 22, 2022
 
 Points of contact: David Kanter (dkanter@gmail.com), Steve Farrell (sfarrell@lbl.gov)
 
 == Overview
-
-All rules are taken from the MLPerf Training Rules (the version at the time of HPC rules freeze) except for those that are overridden here. 
+2
+All rules are taken from the MLPerf Training Rules, the version at the time of HPC rules freeze, https://github.com/mlcommons/training_policies/commit/5a910009c991cb3b98448c9baf60b7ba018c3c06 except for those that are overridden here.
 
 The MLPerf name and logo are trademarks. In order to refer to a result using the
 MLPerf name, the result must conform to the letter and spirit of the rules


### PR DESCRIPTION
Added text to state the training rules version applicable at the time of HPC rules freeze.