### PR TITLE
[DLRMv2] Require at least 10 results due to higher convergence variance for the new benchmark

### DIFF
--- a/training_rules.adoc
+++ b/training_rules.adoc
@@ -486,7 +486,7 @@ Each benchmark result is based on a set of run results. The number of results fo
 |Language |NLP |10
 | |Speech recognition |10
 | |Large language model |3
-|Commerce |Recommendation |5
+|Commerce |Recommendation |10
 |===
 
 Each benchmark result is computed by dropping the fastest and slowest runs, then taking the mean of the remaining times. For this purpose, a single non-converging run may be treated as the slowest run and dropped. A benchmark result is invalid if there is more than one non-converging run. 


### PR DESCRIPTION
Author: Jan Lasek, Nvidia (jlasek_at_nvidia_dot_com)

Previous recommender benchmark was very stable in terms of convergence, see [DLRM RCP data](https://github.com/mlcommons/logging/blob/f7a94546583de8e55855938dd544e7f5d8bebf54/mlperf_logging/rcp_checker/training_2.1.0/rcps_dlrm.json). The new benchmark shows much higher variance for convergence, see [DLRMv2 RCP stats](https://github.com/mlcommons/logging/blob/f7a94546583de8e55855938dd544e7f5d8bebf54/mlperf_logging/rcp_checker/training_3.0.0/rcps_dlrmv2.json).

Therefore, to account for that we suggest to increase the number of required runs for a submission to 10.

cc @erichan1 @johntran-nv