### PR TITLE
Add back rules for deprecated benchmarks

### DIFF
--- a/training_rules.adoc
+++ b/training_rules.adoc
@@ -74,15 +74,21 @@ For benchmarks which are defined as starting from a fixed set of weights, such a
 The benchmark suite consists of the benchmarks shown in the following table.
 
 |===
-|Area|Problem |Dataset
+|Area|Problem |Dataset |Latest version available
 
-|Vision |Object detection (light weight) |A subset of OpenImages
-| |Text to Image |LAION-400M-filtered
-|Language |NLP |Wikipedia 2020/01/01
-| |Large language model |c4/en/3.0.1
-| |Large language model |SCROLLS GovReport
-|Commerce |Recommendation |Criteo 3.5TB Click Logs (multi-hot variant)
-|Graphs | Node classification | IGBH-Full 
+|Vision |Object detection (light weight) |A subset of OpenImages |v4.1
+| |Text to Image |LAION-400M-filtered |v4.1
+|Language |NLP |Wikipedia 2020/01/01 |v4.1
+| |Large language model |c4/en/3.0.1 |v4.1
+| |Large language model |SCROLLS GovReport |v4.1
+|Commerce |Recommendation |Criteo 3.5TB Click Logs (multi-hot variant) |v4.1
+|Graphs | Node classification | IGBH-Full |v4.1
+|Vision |Image classification |ImageNet |v4.0
+| |Image segmentation (medical) |KiTS19 |v4.0
+|Vision |Object detection (heavy weight) |COCO |v3.1
+|Language |Speech recognition |LibriSpeech |v3.1
+|Commerce |Recommendation |Criteo 1TB Click Logs (multi-hot variant) |v2.1
+
 |===
 
 MLCommons provides a reference implementation of each benchmark, which includes the following elements:
@@ -130,15 +136,19 @@ The Closed division requires using the same preprocessing, model, training metho
 The closed division models and quality targets are:
 
 |===
-|Area |Problem |Model |Target
+|Area |Problem |Model |Target |Latest version available
 
-|Vision |Object detection (light weight) |SSD (RetinaNet) |34.0% mAP
-| |Text to image |Stable Diffusion v2.0 |FID<=90 and and CLIP>=0.15
-|Language |NLP |BERT |0.720 Mask-LM accuracy
-| |Large Language Model |GPT3 |2.69 log perplexity
-| |Large Language Model |Llama2-70B-LoRA |0.925 Eval loss
-|Commerce |Recommendation |DLRMv2 (DCNv2) |0.80275 AUC
-|Graphs | Node classification|R-GAT | 72.0 % classification
+|Vision |Object detection (light weight) |SSD (RetinaNet) |34.0% mAP |v4.1
+| |Text to image |Stable Diffusion v2.0 |FID<=90 and and CLIP>=0.15 |v4.1
+|Language |NLP |BERT |0.720 Mask-LM accuracy |v4.1
+| |Large Language Model |GPT3 |2.69 log perplexity |v4.1
+| |Large Language Model |Llama2-70B-LoRA |0.925 Eval loss |v4.1
+|Commerce |Recommendation |DLRMv2 (DCNv2) |0.80275 AUC |v4.1
+|Graphs | Node classification|R-GAT | 72.0 % classification |v4.1
+|Vision |Image classification |ResNet-50 v1.5 |75.90% classification |v4.0
+| |Image segmentation (medical) |U-Net3D |0.908 Mean DICE score |v4.0
+|Vision |Object detection (heavy weight) |Mask R-CNN |0.377 Box min AP and 0.339 Mask min AP |v3.1
+|Language | Speech recognition | RNN-T | 0.058 Word Error Rate |v3.1
 |===
 
 Closed division benchmarks must be referred to using the benchmark name plus the term Closed, e.g. “for the Recommendation Closed benchmark, the system achieved a result of 7.2.”
@@ -262,65 +272,141 @@ The following table lists the tunable hyperparameters for each allowed model,opt
 The MLPerf verifier scripts checks all hyperparameters except those with names marked with asterisks. If a hyperparameter is marked with one asterisk, it must be checked manually. If a hyperparameter is marked with two asterisks, it is also not logged and it must be checked manually in the code.  If the verifier and the constraints in this table differ, the verifier (specifically, the version on the date of submission unless otherwise decided by the review committee) is the source of truth.
 
 |===
- |Model |Optimizer |Name |Constraint |Definition |Reference Code
+ |Model |Optimizer |Name |Constraint |Definition |Reference Code |Latest version available
 
-|bert |lamb |global_batch_size |unconstrained |The glboal batch size for training. |--train_batch_size
- |bert |lamb |opt_base_learning_rate |unconstrained |The base learning rate. |--learning_rate
- |bert |lamb |opt_epsilon |unconstrained |adam epsilon |link:https://github.com/mlperf/training/blob/fb058e3849c25f6c718434e60906ea3b0cb0f67d/language_model/tensorflow/bert/optimization.py#L75[reference code]
- |bert |lamb |opt_learning_rate_training_steps |unconstrained |Step at which your reach the lowest learning late |link:https://github.com/mlperf/training/blob/master/language_model/tensorflow/bert/run_pretraining.py#L64[reference code]
- |bert |lamb |opt_learning_rate_warmup_steps |unconstrained |"num_warmup_steps" |link:https://github.com/mlperf/training/blob/master/language_model/tensorflow/bert/optimization.py#L34[reference code]
- |bert |lamb |num_warmup_steps |unconstrained |Number of steps for linear warmup. |--num_warmup_steps
- |bert |lamb |start_warmup_step |unconstrained |--start_warmup_step |--start_warmup_step
- |bert |lamb |opt_lamb_beta_1 |unconstrained |adam beta1 |link:https://github.com/mlperf/training/blob/fb058e3849c25f6c718434e60906ea3b0cb0f67d/language_model/tensorflow/bert/optimization.py#L73[reference code]
- |bert |lamb |opt_lamb_beta_2 |unconstrained |adam beta2 |link:https://github.com/mlperf/training/blob/fb058e3849c25f6c718434e60906ea3b0cb0f67d/language_model/tensorflow/bert/optimization.py#L74[reference code]
- |bert |lamb |opt_lamb_weight_decay_rate |unconstrained |Weight decay |link:https://github.com/mlperf/training/blob/fb058e3849c25f6c718434e60906ea3b0cb0f67d/language_model/tensorflow/bert/optimization.py#L72[reference code]
- |dlrmv2 |adagrad |global_batch_size |unconstrained |global batch size |link:https://github.com/mlcommons/training/blob/a9056b8e5840d811484ad91f9fe23ed09a3f97cf/recommendation_v2/torchrec_dlrm/dlrm_main.py#L705-L708[reference code]
- |dlrmv2 |adagrad |opt_base_learning_rate |unconstrained |learning rate (for both dense layers and embeddings) |link:https://github.com/mlcommons/training/blob/a9056b8e5840d811484ad91f9fe23ed09a3f97cf/recommendation_v2/torchrec_dlrm/dlrm_main.py#L230-L235[reference code]
- |dlrmv2 |adagrad |opt_adagrad_learning_rate_decay |0.0 |learning rate decay |link:https://github.com/mlcommons/training/blob/a9056b8e5840d811484ad91f9fe23ed09a3f97cf/recommendation_v2/torchrec_dlrm/dlrm_main.py#L73[reference code]
- |dlrmv2 |adagrad |opt_weight_decay |0.0 |weight decay |link:https://github.com/mlcommons/training/blob/a9056b8e5840d811484ad91f9fe23ed09a3f97cf/recommendation_v2/torchrec_dlrm/dlrm_main.py#L76[reference code]
- |dlrmv2 |adagrad |opt_adagrad_initial_accumulator_value |0.0 |adagrad initial accumulator value |link:https://github.com/mlcommons/training/blob/a9056b8e5840d811484ad91f9fe23ed09a3f97cf/recommendation_v2/torchrec_dlrm/dlrm_main.py#L74[reference code]
- |dlrmv2 |adagrad |opt_adagrad_epsilon |1e-8 |adagrad epsilon |link:https://github.com/mlcommons/training/blob/a9056b8e5840d811484ad91f9fe23ed09a3f97cf/recommendation_v2/torchrec_dlrm/dlrm_main.py#L75[reference code]
- |dlrmv2 |adagrad |opt_learning_rate_warmup_steps |0 (disabled) |number to steps from 0 to sgd_opt_base_learning_rate with a linear warmup |link:https://github.com/mlcommons/training/blob/a9056b8e5840d811484ad91f9fe23ed09a3f97cf/recommendation_v2/torchrec_dlrm/dlrm_main.py#L303-L307[reference code]
- |dlrmv2 |adagrad |opt_learning_rate_decay_start_step |0 (disabled) |step at which poly decay is started |link:https://github.com/mlcommons/training/blob/a9056b8e5840d811484ad91f9fe23ed09a3f97cf/recommendation_v2/torchrec_dlrm/dlrm_main.py#L308-L312[reference code]
- |dlrmv2 |adagrad |opt_learning_rate_decay_steps |0 (disabled) |the step at which the end learning rate is reached |link:https://github.com/mlcommons/training/blob/a9056b8e5840d811484ad91f9fe23ed09a3f97cf/recommendation_v2/torchrec_dlrm/dlrm_main.py#L313-L317[reference code]
- |gpt3 |adam |global_batch_size |unconstrained |batch size in sequences |See PR (From NV and Google, TODO Link)
- |gpt3 |adam |opt_adam_beta_1 |0.9 |adam beta1 |See PR (From NV and Google, TODO Link)
- |gpt3 |adam |opt_adam_beta_2 |0.95 |adam beta2 |See PR (From NV and Google, TODO Link)
- |gpt3 |adam |opt_adam_epsilon |1e-8 |adam epsilon |See PR (From NV and Google, TODO Link)
- |gpt3 |adam |opt_gradient_clip_norm |1.0 |Gradients are clipped above this norm threshold. |See PR (From NV and Google, TODO Link)
- |gpt3 |adam |dropout |0.0 |Disable all dropouts during training. |See PR (From NV and Google, TODO Link)
- |gpt3 |adam |sequence_length |2048 |sequence length |See PR (From NV and Google, TODO Link)
- |gpt3 |adam |opt_weight_decay |0.1 |weight decay |See PR (From NV and Google, TODO Link)
- |gpt3 |adam |gradient_accumulation_steps |unconstrained |Numer of fwd/bwd steps between optimizer step. |See PR (From NV and Google, TODO Link)
- |gpt3 |adam |opt_learning_rate_warmup_steps |ceil(265 * 1536 / global_batch_size) |steps taken for linear warmup during initial checkpoint generation. This only affects the learning rate curve in the benchmarking region. |See PR (From NV and Google, TODO Link)
- |gpt3 |adam |opt_learning_rate_decay_steps |ceil(108600 * 1536 / global_batch_size) |Step when the end of cosine learning rate curve is reached. Learning rate cosine decay is in range (opt_learning_rate_warmup_steps + 1,opt_learning_rate_decay_steps]. |See PR (From NV and Google, TODO Link)
- |gpt3 |adam |opt_init_checkpoint_step |ceil(4000 * 1536 / batch_size) |first step after loading initial checkpoint |See PR (From NV and Google, TODO Link)
- |gpt3 |adam |opt_base_learning_rate |constrained based on global_batch_size |refer to next table in section "GPT3 learning rates" |See PR (From NV and Google, TODO Link)
- |gpt3 |adam |opt_end_learning_rate |10% of opt_base_learning_rate |learning rate at the last step of decay period |See PR (From NV and Google, TODO Link)
- |llama2_70b_lora |adamw |global_batch_size |unconstrained |batch size in sequences |See PR (From NV and Habana, TODO Link)
- |llama2_70b_lora |adamw |opt_gradient_clip_norm |fixed to referance (0.3) | Gradients are clipped above this norm threshold. |See PR (From Habana, TODO Link)
- |llama2_70b_lora |adamw |lora_dropout |0.1 |fixed to reference (0.1). |See PR (From Habana, TODO Link)
- |llama2_70b_lora |adamw |sequence_length |8196 |the sequence length - fixed to reference |See PR (From Habana, TODO Link)
- |llama2_70b_lora |adamw |lora_alpha |fixed to referance (32) | scaling factor for the LoRA weight matrices |See PR (From Habana, TODO Link)
- |llama2_70b_lora |adamw |opt_weight_decay |fixed to referance (0.0001) |weight decay |See PR (From Habana, TODO Link)
- |llama2_70b_lora |adamw |gradient_accumulation_steps |unconstrained |Numer of fwd/bwd steps between optimizer step. |See PR (From Habana, TODO Link)
- |llama2_70b_lora |adamw |opt_learning_rate_warmup_ratio | unconstrained |ratio of steps out of training for linear warmup during initial checkpoint generation. This only affects the learning rate curve in the benchmarking region. |See PR (From Habana, TODO Link)
- |llama2_70b_lora |adamw |opt_learning_rate_training_steps | unconstrained |Step when the end of cosine learning rate curve is reached. Learning rate cosine decay is in range (opt_learning_rate_warmup_steps + 1,opt_learning_rate_decay_steps]. |See PR (From Habana, TODO Link)
- |llama2_70b_lora |adamw |opt_base_learning_rate |unconstrained | base leraning rate |See PR (From Habana, TODO Link)
- |stable diffusion |adamw |global_batch_size |unconstrained |The glboal batch size for training |link:https://github.com/mlcommons/training/blob/master/stable_diffusion/main.py#L633[reference code]
- |stable diffusion |adamw |opt_adamw_beta_1 |0.9 |coefficients used for computing running averages of gradient and its square |link:https://github.com/mlcommons/training/blob/master/stable_diffusion/ldm/models/diffusion/ddpm.py#L1629[reference code]
- |stable diffusion |adamw |opt_adamw_beta_2 |0.999 |coefficients used for computing running averages of gradient and its square |link:https://github.com/mlcommons/training/blob/master/stable_diffusion/ldm/models/diffusion/ddpm.py#L1630[reference code]
- |stable diffusion |adamw |opt_adamw_epsilon |1e-08 |term added to the denominator to improve numerical stability |link:https://github.com/mlcommons/training/blob/master/stable_diffusion/ldm/models/diffusion/ddpm.py#L1631[reference code]
- |stable diffusion |adamw |opt_adamw_weight_decay |0.01 |weight decay coefficient |link:https://github.com/mlcommons/training/blob/master/stable_diffusion/ldm/models/diffusion/ddpm.py#L1632[reference code]
- |stable diffusion |adamw |opt_base_learning_rate |unconstrained |base learning rate, this should be the learning rate after warm up |link:https://github.com/mlcommons/training/blob/master/stable_diffusion/ldm/models/diffusion/ddpm.py#L1633[reference code]
- |stable diffusion |adamw |opt_learning_rate_warmup_steps |unconstrained |number of steps for learning rate to warm up |link:https://github.com/mlcommons/training/blob/master/stable_diffusion/ldm/models/diffusion/ddpm.py#L1639[reference code]
- |ssd |adam |global_batch_size |arbitrary constant |reference --batch-size |link:https://github.com/mlperf/training/blob/master/single_stage_detector/ssd/train.py#L80[reference code]
- |ssd |adam |opt_learning_rate_warmup_epochs |integer >= 0 |number of epochs for learning rate to warm up |link:https://github.com/mlperf/training/blob/master/single_stage_detector/ssd/train.py#L87[reference code]
- |ssd |adam |opt_learning_rate_warmup_factor |unconstrained |the constant factor applied at learning rate warm up |link:https://github.com/mlperf/training/blob/master/single_stage_detector/ssd/train.py#L89[reference code]
- |ssd |adam |opt_base_learning_rate |unconstrained |base learning rate, this should be the learning rate after warm up and before decay |link:https://github.com/mlperf/training/blob/master/single_stage_detector/ssd/train.py#L84[reference code]
- |ssd |adam |opt_weight_decay |0 |L2 weight decay |link:https://github.com/mlperf/training/blob/master/single_stage_detector/ssd/train.py#L171[reference code]
- |gnn |adam |global_batch_size |arbitrary constant |global batch size |link:https://github.com/alibaba/graphlearn-for-pytorch/blob/main/examples/igbh/train_rgnn_multi_gpu.py#L293[reference code]
- |gnn |adam |opt_base_learning_rate |unconstrained |base learning rate|link:https://github.com/alibaba/graphlearn-for-pytorch/blob/main/examples/igbh/train_rgnn_multi_gpu.py#L296[reference code]
+|bert |lamb |global_batch_size |unconstrained |The glboal batch size for training. |--train_batch_size |v4.1
+ |bert |lamb |opt_base_learning_rate |unconstrained |The base learning rate. |--learning_rate |v4.1
+ |bert |lamb |opt_epsilon |unconstrained |adam epsilon |link:https://github.com/mlperf/training/blob/fb058e3849c25f6c718434e60906ea3b0cb0f67d/language_model/tensorflow/bert/optimization.py#L75[reference code] |v4.1
+ |bert |lamb |opt_learning_rate_training_steps |unconstrained |Step at which your reach the lowest learning late |link:https://github.com/mlperf/training/blob/master/language_model/tensorflow/bert/run_pretraining.py#L64[reference code] |v4.1
+ |bert |lamb |opt_learning_rate_warmup_steps |unconstrained |"num_warmup_steps" |link:https://github.com/mlperf/training/blob/master/language_model/tensorflow/bert/optimization.py#L34[reference code] |v4.1
+ |bert |lamb |num_warmup_steps |unconstrained |Number of steps for linear warmup. |--num_warmup_steps |v4.1
+ |bert |lamb |start_warmup_step |unconstrained |--start_warmup_step |--start_warmup_step |v4.1
+ |bert |lamb |opt_lamb_beta_1 |unconstrained |adam beta1 |link:https://github.com/mlperf/training/blob/fb058e3849c25f6c718434e60906ea3b0cb0f67d/language_model/tensorflow/bert/optimization.py#L73[reference code] |v4.1
+ |bert |lamb |opt_lamb_beta_2 |unconstrained |adam beta2 |link:https://github.com/mlperf/training/blob/fb058e3849c25f6c718434e60906ea3b0cb0f67d/language_model/tensorflow/bert/optimization.py#L74[reference code] |v4.1
+ |bert |lamb |opt_lamb_weight_decay_rate |unconstrained |Weight decay |link:https://github.com/mlperf/training/blob/fb058e3849c25f6c718434e60906ea3b0cb0f67d/language_model/tensorflow/bert/optimization.py#L72[reference code] |v4.1
+ |dlrmv2 |adagrad |global_batch_size |unconstrained |global batch size |link:https://github.com/mlcommons/training/blob/a9056b8e5840d811484ad91f9fe23ed09a3f97cf/recommendation_v2/torchrec_dlrm/dlrm_main.py#L705-L708[reference code] |v4.1
+ |dlrmv2 |adagrad |opt_base_learning_rate |unconstrained |learning rate (for both dense layers and embeddings) |link:https://github.com/mlcommons/training/blob/a9056b8e5840d811484ad91f9fe23ed09a3f97cf/recommendation_v2/torchrec_dlrm/dlrm_main.py#L230-L235[reference code] |v4.1
+ |dlrmv2 |adagrad |opt_adagrad_learning_rate_decay |0.0 |learning rate decay |link:https://github.com/mlcommons/training/blob/a9056b8e5840d811484ad91f9fe23ed09a3f97cf/recommendation_v2/torchrec_dlrm/dlrm_main.py#L73[reference code] |v4.1
+ |dlrmv2 |adagrad |opt_weight_decay |0.0 |weight decay |link:https://github.com/mlcommons/training/blob/a9056b8e5840d811484ad91f9fe23ed09a3f97cf/recommendation_v2/torchrec_dlrm/dlrm_main.py#L76[reference code] |v4.1
+ |dlrmv2 |adagrad |opt_adagrad_initial_accumulator_value |0.0 |adagrad initial accumulator value |link:https://github.com/mlcommons/training/blob/a9056b8e5840d811484ad91f9fe23ed09a3f97cf/recommendation_v2/torchrec_dlrm/dlrm_main.py#L74[reference code] |v4.1
+ |dlrmv2 |adagrad |opt_adagrad_epsilon |1e-8 |adagrad epsilon |link:https://github.com/mlcommons/training/blob/a9056b8e5840d811484ad91f9fe23ed09a3f97cf/recommendation_v2/torchrec_dlrm/dlrm_main.py#L75[reference code] |v4.1
+ |dlrmv2 |adagrad |opt_learning_rate_warmup_steps |0 (disabled) |number to steps from 0 to sgd_opt_base_learning_rate with a linear warmup |link:https://github.com/mlcommons/training/blob/a9056b8e5840d811484ad91f9fe23ed09a3f97cf/recommendation_v2/torchrec_dlrm/dlrm_main.py#L303-L307[reference code] |v4.1
+ |dlrmv2 |adagrad |opt_learning_rate_decay_start_step |0 (disabled) |step at which poly decay is started |link:https://github.com/mlcommons/training/blob/a9056b8e5840d811484ad91f9fe23ed09a3f97cf/recommendation_v2/torchrec_dlrm/dlrm_main.py#L308-L312[reference code] |v4.1
+ |dlrmv2 |adagrad |opt_learning_rate_decay_steps |0 (disabled) |the step at which the end learning rate is reached |link:https://github.com/mlcommons/training/blob/a9056b8e5840d811484ad91f9fe23ed09a3f97cf/recommendation_v2/torchrec_dlrm/dlrm_main.py#L313-L317[reference code] |v4.1
+ |gpt3 |adam |global_batch_size |unconstrained |batch size in sequences |See PR (From NV and Google, TODO Link) |v4.1
+ |gpt3 |adam |opt_adam_beta_1 |0.9 |adam beta1 |See PR (From NV and Google, TODO Link) |v4.1
+ |gpt3 |adam |opt_adam_beta_2 |0.95 |adam beta2 |See PR (From NV and Google, TODO Link) |v4.1
+ |gpt3 |adam |opt_adam_epsilon |1e-8 |adam epsilon |See PR (From NV and Google, TODO Link) |v4.1
+ |gpt3 |adam |opt_gradient_clip_norm |1.0 |Gradients are clipped above this norm threshold. |See PR (From NV and Google, TODO Link) |v4.1
+ |gpt3 |adam |dropout |0.0 |Disable all dropouts during training. |See PR (From NV and Google, TODO Link) |v4.1
+ |gpt3 |adam |sequence_length |2048 |sequence length |See PR (From NV and Google, TODO Link) |v4.1
+ |gpt3 |adam |opt_weight_decay |0.1 |weight decay |See PR (From NV and Google, TODO Link) |v4.1
+ |gpt3 |adam |gradient_accumulation_steps |unconstrained |Numer of fwd/bwd steps between optimizer step. |See PR (From NV and Google, TODO Link) |v4.1
+ |gpt3 |adam |opt_learning_rate_warmup_steps |ceil(265 * 1536 / global_batch_size) |steps taken for linear warmup during initial checkpoint generation. This only affects the learning rate curve in the benchmarking region. |See PR (From NV and Google, TODO Link) |v4.1
+ |gpt3 |adam |opt_learning_rate_decay_steps |ceil(108600 * 1536 / global_batch_size) |Step when the end of cosine learning rate curve is reached. Learning rate cosine decay is in range (opt_learning_rate_warmup_steps + 1,opt_learning_rate_decay_steps]. |See PR (From NV and Google, TODO Link) |v4.1
+ |gpt3 |adam |opt_init_checkpoint_step |ceil(4000 * 1536 / batch_size) |first step after loading initial checkpoint |See PR (From NV and Google, TODO Link) |v4.1
+ |gpt3 |adam |opt_base_learning_rate |constrained based on global_batch_size |refer to next table in section "GPT3 learning rates" |See PR (From NV and Google, TODO Link) |v4.1
+ |gpt3 |adam |opt_end_learning_rate |10% of opt_base_learning_rate |learning rate at the last step of decay period |See PR (From NV and Google, TODO Link) |v4.1
+ |llama2_70b_lora |adamw |global_batch_size |unconstrained |batch size in sequences |See PR (From NV and Habana, TODO Link) |v4.1
+ |llama2_70b_lora |adamw |opt_gradient_clip_norm |fixed to referance (0.3) | Gradients are clipped above this norm threshold. |See PR (From Habana, TODO Link) |v4.1
+ |llama2_70b_lora |adamw |lora_dropout |0.1 |fixed to reference (0.1). |See PR (From Habana, TODO Link) |v4.1
+ |llama2_70b_lora |adamw |sequence_length |8196 |the sequence length - fixed to reference |See PR (From Habana, TODO Link) |v4.1
+ |llama2_70b_lora |adamw |lora_alpha |fixed to referance (32) | scaling factor for the LoRA weight matrices |See PR (From Habana, TODO Link) |v4.1
+ |llama2_70b_lora |adamw |opt_weight_decay |fixed to referance (0.0001) |weight decay |See PR (From Habana, TODO Link) |v4.1
+ |llama2_70b_lora |adamw |gradient_accumulation_steps |unconstrained |Numer of fwd/bwd steps between optimizer step. |See PR (From Habana, TODO Link) |v4.1
+ |llama2_70b_lora |adamw |opt_learning_rate_warmup_ratio | unconstrained |ratio of steps out of training for linear warmup during initial checkpoint generation. This only affects the learning rate curve in the benchmarking region. |See PR (From Habana, TODO Link) |v4.1
+ |llama2_70b_lora |adamw |opt_learning_rate_training_steps | unconstrained |Step when the end of cosine learning rate curve is reached. Learning rate cosine decay is in range (opt_learning_rate_warmup_steps + 1,opt_learning_rate_decay_steps]. |See PR (From Habana, TODO Link) |v4.1
+ |llama2_70b_lora |adamw |opt_base_learning_rate |unconstrained | base leraning rate |See PR (From Habana, TODO Link) |v4.1
+ |stable diffusion |adamw |global_batch_size |unconstrained |The glboal batch size for training |link:https://github.com/mlcommons/training/blob/master/stable_diffusion/main.py#L633[reference code] |v4.1
+ |stable diffusion |adamw |opt_adamw_beta_1 |0.9 |coefficients used for computing running averages of gradient and its square |link:https://github.com/mlcommons/training/blob/master/stable_diffusion/ldm/models/diffusion/ddpm.py#L1629[reference code] |v4.1
+ |stable diffusion |adamw |opt_adamw_beta_2 |0.999 |coefficients used for computing running averages of gradient and its square |link:https://github.com/mlcommons/training/blob/master/stable_diffusion/ldm/models/diffusion/ddpm.py#L1630[reference code] |v4.1
+ |stable diffusion |adamw |opt_adamw_epsilon |1e-08 |term added to the denominator to improve numerical stability |link:https://github.com/mlcommons/training/blob/master/stable_diffusion/ldm/models/diffusion/ddpm.py#L1631[reference code] |v4.1
+ |stable diffusion |adamw |opt_adamw_weight_decay |0.01 |weight decay coefficient |link:https://github.com/mlcommons/training/blob/master/stable_diffusion/ldm/models/diffusion/ddpm.py#L1632[reference code] |v4.1
+ |stable diffusion |adamw |opt_base_learning_rate |unconstrained |base learning rate, this should be the learning rate after warm up |link:https://github.com/mlcommons/training/blob/master/stable_diffusion/ldm/models/diffusion/ddpm.py#L1633[reference code] |v4.1
+ |stable diffusion |adamw |opt_learning_rate_warmup_steps |unconstrained |number of steps for learning rate to warm up |link:https://github.com/mlcommons/training/blob/master/stable_diffusion/ldm/models/diffusion/ddpm.py#L1639[reference code] |v4.1
+ |ssd |adam |global_batch_size |arbitrary constant |reference --batch-size |link:https://github.com/mlperf/training/blob/master/single_stage_detector/ssd/train.py#L80[reference code] |v4.1
+ |ssd |adam |opt_learning_rate_warmup_epochs |integer >= 0 |number of epochs for learning rate to warm up |link:https://github.com/mlperf/training/blob/master/single_stage_detector/ssd/train.py#L87[reference code] |v4.1
+ |ssd |adam |opt_learning_rate_warmup_factor |unconstrained |the constant factor applied at learning rate warm up |link:https://github.com/mlperf/training/blob/master/single_stage_detector/ssd/train.py#L89[reference code] |v4.1
+ |ssd |adam |opt_base_learning_rate |unconstrained |base learning rate, this should be the learning rate after warm up and before decay |link:https://github.com/mlperf/training/blob/master/single_stage_detector/ssd/train.py#L84[reference code] |v4.1
+ |ssd |adam |opt_weight_decay |0 |L2 weight decay |link:https://github.com/mlperf/training/blob/master/single_stage_detector/ssd/train.py#L171[reference code] |v4.1
+ |gnn |adam |global_batch_size |arbitrary constant |global batch size |link:https://github.com/alibaba/graphlearn-for-pytorch/blob/main/examples/igbh/train_rgnn_multi_gpu.py#L293[reference code] |v4.1
+ |gnn |adam |opt_base_learning_rate |unconstrained |base learning rate|link:https://github.com/alibaba/graphlearn-for-pytorch/blob/main/examples/igbh/train_rgnn_multi_gpu.py#L296[reference code] |v4.1
+ |resnet |lars |lars_opt_base_learning_rate |arbitrary constant |Base "plr" in the PR linked. |link:https://github.com/mlperf/training/pull/342/files#[reference code] |v4.0
+ |resnet |lars |lars_opt_end_learning_rate$$*$$ |fixed to reference |end learning rate for polynomial decay, implied mathemetically from other HPs |N/A |v4.0
+ |resnet |lars |lars_opt_learning_rate_decay_poly_power$$*$$ |fixed to reference |power of polynomial decay, no link needed since not tunable |N/A |v4.0
+ |resnet |lars |lars_epsilon$$*$$ |Fixed to reference |epsilon in reference |link:https://github.com/mlperf/training/pull/342/files#diff-b7db7d58acb8134acb65b4d1d60b8e90R49[reference code] |v4.0
+ |resnet |lars |lars_opt_learning_rate_warmup_epochs |arbitrary constant |w_epochs in PR |link:https://github.com/mlperf/training/pull/342/files#[reference code] |v4.0
+ |resnet |lars |lars_opt_momentum | 0.9 for batch<32k, otherwise arbitrary constant |momentum in reference |link:https://github.com/mlperf/training/pull/342/files#diff-b7db7d58acb8134acb65b4d1d60b8e90R49[reference code] |v4.0
+ |resnet |lars |lars_opt_weight_decay |(0.0001 * 2 ^ N) where N is any integer |weight_decay in  reference |link:https://github.com/mlperf/training/pull/342/files#diff-b7db7d58acb8134acb65b4d1d60b8e90R49[reference code] |v4.0
+ |resnet |lars |lars_opt_learning_rate_decay_steps |unconstrained |num_epochs in reference |link:https://github.com/mlperf/training/blob/master/image_classification/tensorflow/official/resnet/resnet_run_loop.py[reference code] |v4.0
+ |resnet |lars |global_batch_size |unconstrained |global batch size in reference
+|link:https://github.com/mlperf/training/blob/00570abf77d351e474d57830014f6a3e501dece1/image_classification/tensorflow/official/utils/arg_parsers/parsers.py#L158[reference code] |v4.0
+ |resnet |lars |label smoothing$$*$$$$*$$ |0 or 0.1 | TODO |TODO |v4.0
+ |resnet |lars |truncated norm initialization$$*$$$$*$$ |boolean | TODO |TODO |v4.0
+ |resnet |sgd |global_batch_size |arbitrary constant |reference --batch_size |See LARS |v4.0
+ |resnet |sgd |sgd_opt_base_learning_rate |0.001 * k where is an integer  |the learning rate |See LARS |v4.0
+ |resnet |sgd |sgd_opt_end_learning_rate |10^-4 |end learning rate for polynomial decay, implied mathemetically from other HPs |See LARS |v4.0
+ |resnet |sgd |sgd_opt_learning_rate_decay_poly_power |2 |power of polynomial decay, no link needed since not tunable |See LARS |v4.0
+ |resnet |sgd |sgd_opt_learning_rate_decay_steps |integer >= 0 |num_epochs in reference |See LARS |v4.0
+ |resnet |sgd |sgd_opt_weight_decay |(0.0001 * 2 ^ N) where N is any integer |Weight decay, same as LARS. |See LARS |v4.0
+ |resnet |sgd |sgd_opt_momentum |0.9 |Momentum for SGD. |See LARS |v4.0
+ |resnet |sgd |model_bn_span |arbitrary constant |number of samples whose statistics a given BN layer uses to normalize a training minibatch (may be just the portion of global_batch_size per device, but also may be aggregated over several devices) |See LARS |v4.0
+ |resnet |sgd |opt_learning_rate_warmup_epochs |integer >= 0 |number of epochs needed for learning rate warmup |See LARS |v4.0
+ |resnet |sgd |label smoothing$$*$$$$*$$ |0 or 0.1 | TODO |TODO |v4.0
+ |resnet |sgd |truncated norm initialization$$*$$$$*$$ |boolean | TODO |TODO |v4.0
+ |resnet |lars/sgd |opt_name |"lars" or "sgd" |The optimizer that was used. | |v4.0
+ |unet3d |sgd |global_batch_size |unconstrained |global batch size |reference --batch_size |v4.0
+ |unet3d |sgd |opt_base_learning_rate |unconstrained |base learning rate |reference --learning_rate |v4.0
+ |unet3d |sgd |opt_momentum |unconstrained |SGD momentum |reference --momentum |v4.0
+ |unet3d |sgd |opt_learning_rate_warmup_steps |unconstrained |number of epochs needed for learning rate warmup|reference --lr_warmup_epochs |v4.0
+ |unet3d |sgd |opt_initial_learning_rate |unconstrained |initial learning rate (for LR warm up) |reference --init_learning_rate |v4.0
+ |unet3d |sgd |opt_learning_rate_decay_steps |unconstrained |epochs at which the learning rate decays |reference --lr_decay_epochs |v4.0
+ |unet3d |sgd |opt_learning_rate_decay_factor |unconstrained |factor used for learning rate decay |reference --lr_decay_factor |v4.0
+ |unet3d |sgd |opt_weight_decay |unconstrained |L2 weight decay |reference --weight_decay |v4.0
+ |unet3d |sgd |training_oversampling |fixed to reference |training oversampling |reference --oversampling |v4.0
+ |unet3d |sgd |training_input_shape |fixed to reference |training input shape |reference --input_shape |v4.0
+ |unet3d |sgd |evaluation_overlap |fixed to reference |evaluation sliding window overlap |reference --overlap |v4.0
+ |unet3d |sgd |evaluation_input_shape |fixed to reference |evaluation input shape |reference --val_input_shape |v4.0
+ |unet3d |sgd |data_train_samples |fixed to reference |number of training samples | N/A |v4.0
+ |unet3d |sgd |data_eval_samples |fixed to reference |number of evaluation samples | N/A |v4.0
+ |maskrcnn |sgd |global_batch_size |arbitrary constant |global version of reference SOLVER.IMS_PER_BATCH |link:https://github.com/mlperf/training/blob/00570abf77d351e474d57830014f6a3e501dece1/object_detection/pytorch/maskrcnn_benchmark/data/build.py#L112[reference code] |v3.1
+ |maskrcnn |sgd |opt_learning_rate_decay_factor$$*$$ |fixed to reference (0.1) |learning rate decay factor |link:https://github.com/mlperf/training/blob/00570abf77d351e474d57830014f6a3e501dece1/object_detection/pytorch/maskrcnn_benchmark/solver/build.py#L13[reference code] |v3.1
+ |maskrcnn |sgd |opt_learning_rate_decay_steps$$*$$ |(60000, 80000) * (1 + K / 10) * 16 / global_batch_size where K is integer |Steps at which learning rate is decayed |link:https://github.com/mlperf/training/blob/00570abf77d351e474d57830014f6a3e501dece1/object_detection/pytorch/maskrcnn_benchmark/solver/build.py#L26[reference code] |v3.1
+ |maskrcnn |sgd |opt_base_learning_rate |0.02 * K for any integer K. For global_batch_size < 16, 0.02 / K for any integer K is also allowed |base learning rate, this should be the learning rate after warm up and before decay |link:https://github.com/mlperf/training/blob/00570abf77d351e474d57830014f6a3e501dece1/object_detection/pytorch/maskrcnn_benchmark/solver/build.py#L12[reference code] |v3.1
+ |maskrcnn |sgd |max_image_size$$*$$ |fixed to reference |Maximum size of the longer side |link:https://github.com/mlperf/training/blob/00570abf77d351e474d57830014f6a3e501dece1/object_detection/pytorch/maskrcnn_benchmark/data/transforms/build.py#L8[reference code] |v3.1
+ |maskrcnn |sgd |min_image_size$$*$$ |fixed to reference |Maximum size of the shorter side |link:https://github.com/mlperf/training/blob/00570abf77d351e474d57830014f6a3e501dece1/object_detection/pytorch/maskrcnn_benchmark/data/transforms/build.py#L7[reference code] |v3.1
+ |maskrcnn |sgd |num_image_candidates$$*$$ |1000 or 1000 * batches per chip |tunable number of region proposals for given batch size |link:https://github.com/mlperf/training/blob/00570abf77d351e474d57830014f6a3e501dece1/object_detection/pytorch/maskrcnn_benchmark/modeling/rpn/inference.py#L183[reference code] |v3.1
+ |maskrcnn |sgd |opt_learning_rate_warmup_factor |unconstrained |the constant factor applied at learning rate warm up |link:https://github.com/mlperf/training/blob/00570abf77d351e474d57830014f6a3e501dece1/object_detection/pytorch/maskrcnn_benchmark/solver/build.py#L28[reference code] |v3.1
+ |maskrcnn |sgd |opt_learning_rate_warmup_steps |unconstrained |number of steps for learning rate to warm up |link:https://github.com/mlperf/training/blob/00570abf77d351e474d57830014f6a3e501dece1/object_detection/pytorch/maskrcnn_benchmark/solver/build.py#L29[reference code] |v3.1
+ |rnnt |lamb |global_batch_size                       |unconstrained |reference --batch_size       |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L270-L271[reference code] |v3.1
+ |rnnt |lamb |opt_name                                |"lamb"        |The optimizer that was used. |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L357[reference code] |v3.1
+ |rnnt |lamb |opt_base_learning_rate                  |unconstrained |base learning rate, this should be the learning rate after warm up and before decay  |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L358[reference code] |v3.1
+ |rnnt |lamb |opt_lamb_epsilon                        |1e-9          |LAMB epsilon |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L359[reference code] |v3.1
+ |rnnt |lamb |opt_lamb_learning_rate_decay_poly_power |unconstrained |Exponential decay rate |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L360[reference code] |v3.1
+ |rnnt |lamb |opt_lamb_learning_rate_hold_epochs      |unconstrained |Number of epochs when LR schedule keeps the base learning rate value |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L362[reference code] |v3.1
+ |rnnt |lamb |opt_learning_rate_warmup_epochs         |unconstrained |Number of epochs when LR linearly increases from 0 to base learning rate |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L361[reference code] |v3.1
+ |rnnt |lamb |opt_weight_decay                        |1e-3          |L2 weight decay |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L372[reference code] |v3.1
+ |rnnt |lamb |opt_lamb_beta_1                         |unconstrained |LAMB beta 1 |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L363[reference code] |v3.1
+ |rnnt |lamb |opt_lamb_beta_2                         |unconstrained |LAMB beta 2 |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L364[reference code] |v3.1
+ |rnnt |lamb |opt_gradient_clip_norm                  |1 or inf      |Gradients are clipped above this norm threshold. |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L365[reference code] |v3.1
+ |rnnt |lamb |opt_gradient_accumulation_steps         |unconstrained |Numer of fwd/bwd steps between optimizer step. |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L222[reference code] |v3.1
+ |rnnt |lamb |opt_learning_rate_alt_decay_func        |True          |whether to use alternative learning rate decay function |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/common/optimizers.py#L20-L49[reference code] |v3.1
+ |rnnt |lamb |opt_learning_rate_alt_warmup_func       |True          |whether to use alternative learning rate warmup function |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L367[reference code] |v3.1
+ |rnnt |lamb |opt_lamb_learning_rate_min              |1e-5          |LR schedule doesn't set LR values below this threshold |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L368[reference code] |v3.1
+ |rnnt |lamb |train_samples                           |unconstrained |Number of training samples after filtering out samples longer than data_train_max_duration |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L337[reference code] |v3.1
+ |rnnt |lamb |eval_samples                            |2703          |Number of evaluation samples |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L338[reference code] |v3.1
+ |rnnt |lamb |data_train_max_duration                 |unconstrained |Samples longer than this number of seconds are not included to training dataset |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L252-L253[reference code] |v3.1
+ |rnnt |lamb |data_train_num_buckets                  |unconstrained |Training dataset is split to this number of buckets |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L293[reference code] |v3.1
+ |rnnt |lamb |data_train_speed_perturbation_min       |0.85          |Input audio is resampled to a random rample rate not less than this fraction of original sample rate. |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L256-L257[reference code] |v3.1
+ |rnnt |lamb |data_train_speed_perturbation_max       |1.15          |Input audio is resampled to a random rample rate not greater than this fraction of original sample rate. |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L254-L255[reference code] |v3.1
+ |rnnt |lamb |data_spec_augment_freq_n                |2             |Number of masks for frequency bands |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L258-L259[reference code] |v3.1
+ |rnnt |lamb |data_spec_augment_freq_min              |0             |Minimum number of frequencies in a single mask |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L260-L261[reference code] |v3.1
+ |rnnt |lamb |data_spec_augment_freq_max              |20            |Maximum number of frequencies in a single mask |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L262-L263[reference code] |v3.1
+ |rnnt |lamb |data_spec_augment_time_n                |10            |Number of masks for time band  |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L264-L265[reference code] |v3.1
+ |rnnt |lamb |data_spec_augment_time_min              |0             |Minimum number of masked time steps as a fraction of all steps |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L266-L267[reference code] |v3.1
+ |rnnt |lamb |data_spec_augment_time_max              |0.03          |Maximum number of masked time steps as a fraction of all steps |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L268-L269[reference code] |v3.1
+ |rnnt |lamb |model_eval_ema_factor                   |unconstrained |Smoothing factor for Exponential Moving Average |See link:https://github.com/mlcommons/training/blob/651e7c47bcbd7f4708d633afa567205a826438f1/rnn_speech_recognition/pytorch/train.py#L395[reference code] |v3.1
+ |rnnt |lamb |model_weights_initialization_scale      |unconstrained |After random initialization of weight and bias tensors, all are scaled with this factorAfter random initialization of weight and bias tensors, all are scaled with this factor |See link:https://github.com/mwawrzos/training/blob/2126999a1ffff542064bb3208650a1e673920dcf/rnn_speech_recognition/pytorch/train.py#L342[reference code] |v3.1
 |===
 
 OPEN: Hyperparameters and optimizer may be freely changed. 
@@ -370,15 +456,19 @@ Each run must reach a target quality level on the reference implementation quali
 CLOSED: The same quality measure as the reference implementation must be used. The quality measure must be evaluated at the same frequency (in terms of number of training items between test sets) and at least as thoroughly (in terms of number of tests per set) as in the reference implementation. Where applicable, the required evaluation point may be rounded up to the nearest batch size. Typically, a test consists of comparing the output of one forward pass through the network with the desired output from the test set.
 
 |===
-|Area |Problem |Model|Evaluation frequency
+|Area |Problem |Model|Evaluation frequency |Latest version available
 
-|Vision |Object detection (light weight) |SSD (RetinaNet) |Every 1 epoch
-|       |Text to image |Stable Diffusion v2.0 | See <<benchmark_specific_rules>>
-|Language|NLP |BERT| eval_interval_samples=FLOOR(0.05*(230.23*GBS+3000000), 25000), skipping 0
-|        |large Language Model |GPT3| Every 24576 sequences. CEIL(24576 / global_batch_size) if 24576 is not divisible by GBS
-|        |large Language Model |Llama2_70B_LoRA| Every 384 sequences, CEIL(384 / global_batch_size) steps if 384 is not divisible by GBS. Skipping first FLOOR(0.125*global_batch_size+2) evaluations
-|Commerce|Recommendation |DLRMv2 (DCNv2)|Every FLOOR(TOTAL_TRAINING_SAMPLES / (GLOBAL_BATCH_SIZE * NUM_EVAL) samples, where TOTAL_TRAINING_SAMPLES = 4195197692 and NUM_EVAL = 20
-|Graphs|Node classification|R-GAT|Evaluate 20 times per epoch
+|Vision |Object detection (light weight) |SSD (RetinaNet) |Every 1 epoch |v4.1
+|       |Text to image |Stable Diffusion v2.0 | See <<benchmark_specific_rules>> |v4.1
+|Language|NLP |BERT| eval_interval_samples=FLOOR(0.05*(230.23*GBS+3000000), 25000), skipping 0 |v4.1
+|        |large Language Model |GPT3| Every 24576 sequences. CEIL(24576 / global_batch_size) if 24576 is not divisible by GBS |v4.1
+|        |large Language Model |Llama2_70B_LoRA| Every 384 sequences, CEIL(384 / global_batch_size) steps if 384 is not divisible by GBS. Skipping first FLOOR(0.125*global_batch_size+2) evaluations |v4.1
+|Commerce|Recommendation |DLRMv2 (DCNv2)|Every FLOOR(TOTAL_TRAINING_SAMPLES / (GLOBAL_BATCH_SIZE * NUM_EVAL) samples, where TOTAL_TRAINING_SAMPLES = 4195197692 and NUM_EVAL = 20 |v4.1
+|Graphs|Node classification|R-GAT|Evaluate 20 times per epoch |v4.1
+|Vision |Image classification |Resnet-50 v1.5|Every 4 epochs with offset 0 or 1 or 2 or 3 |v4.0
+|       |Image segmentation (medical) |U-Net3D | Starting at `CEILING(1000*168/samples_per_epoch)` epochs, then every `CEILING(20*168/samples_per_epoch)` epochs. Where `samples_per_epoch` is the number of samples processed in a given epoch assuming that in the case of uneven batches the last batch is padded, e.g. `CEILING(168/global_batch_size) * global_batch_size`. |v4.0
+|Vision |Object detection (heavy weight) |Mask R-CNN|Every 1 epoch |v3.1
+|Language|Speech recognition |RNN-T|Every 1 epoch |v3.1
 |===
 
 OPEN: An arbitrary stopping criteria may be used, including but not limited to the closed quality measure, a different quality measure, the number of epochs, or a fixed time. However, the reported results must include the geometric mean of the final quality as measured by the closed quality measure.
@@ -420,15 +510,19 @@ The clock must start before any part of the system touches the dataset or when t
 Each benchmark result is based on a set of run results. The number of results for each benchmark is based on a combination of the variance of the benchmark result, the cost of each run, and the likelihood of convergence.
 
 |===
-|Area|Problem |Minimum Number of Runs
+|Area|Problem |Minimum Number of Runs |Latest version available
 
-|Vision |Object detection (light weight) |5
-| |Stable Diffusion v2.0 | 10
-|Language |NLP |10
-| |Large language model |3
-| |Large language model Fine Tune (LoRA) |10
-|Commerce |Recommendation |10
-|Graphs|Node classification|10
+|Vision |Object detection (light weight) |5 |v4.1
+| |Stable Diffusion v2.0 | 10 |v4.1
+|Language |NLP |10 |v4.1
+| |Large language model |3 |v4.1
+| |Large language model Fine Tune (LoRA) |10 |v4.1
+|Commerce |Recommendation |10 |v4.1
+|Graphs|Node classification|10 |v4.1
+|Vision |Image classification |5 |v4.0
+| |Image segmentation (medical) | 40 |v4.0
+|Vision |Object detection (heavy weight) |5 |v3.1
+|Language |Speech recognition |10 |v3.1
 |===
 
 Each benchmark result is computed by dropping the fastest and slowest runs, then taking the mean of the remaining times. For this purpose, a single non-converging run may be treated as the slowest run and dropped. A benchmark result is invalid if there is more than one non-converging run.
@@ -485,15 +579,19 @@ During hyperparameter borrowing, borrowers can use hyperparameters from submissi
 
 To extract submission convergence points, logs should report epochs as follows.
 |===
-| Benchmark | Epoch reporting
+| Benchmark | Epoch reporting | Latest version available
 
-| BERT | Training sample (integer)
-| GPT3 | Training token starting from 0 (integer)
-| Llama2_70B_LoRA | Training sample (integer)
-| DLRMv2 (DCNv2) | Training iteration as the fraction of a total number of iterations for one epoch (0.05, 0.1, 0.15, ..., 1.0)
-| Stable-Diffusion | Training sample (integer)
-| SSD (RetinaNet) | Epoch
-| R-GAT | Training iteration as the fraction of a total number of iterations for one epoch (0.05, 0.1, 0.15, ..., 1.0)
+| BERT | Training sample (integer) | v4.1
+| GPT3 | Training token starting from 0 (integer) | v4.1
+| Llama2_70B_LoRA | Training sample (integer) | v4.1
+| DLRMv2 (DCNv2) | Training iteration as the fraction of a total number of iterations for one epoch (0.05, 0.1, 0.15, ..., 1.0) | v4.1
+| Stable-Diffusion | Training sample (integer) | v4.1
+| SSD (RetinaNet) | Epoch | v4.1
+| R-GAT | Training iteration as the fraction of a total number of iterations for one epoch (0.05, 0.1, 0.15, ..., 1.0) | v4.1
+| RN50 | Epoch | v4.0
+| UNET3D | Epoch | v4.0
+| Mask-RCNN | Epoch | v3.1
+| RNN-T | Epoch | v3.1
 |===
 
 === Handling RCP Failures

--- a/training_rules.adoc
+++ b/training_rules.adoc
@@ -51,6 +51,8 @@ A _submission_ is a submission implementation set and a corresponding submission
 
 A _custom summary result_ is the weighted geometric mean of an arbitrary set of results from a specific submission. MLPerf endorses this methodology for computing custom summary results but does not endorse any official summary result.
 
+_latest version available_ is the last MLPerf submission suite that a benchmark was part of.
+
 == General rules
 The following rules apply to all benchmark implementations.
 


### PR DESCRIPTION
https://github.com/mlcommons/training_policies/pull/541 removed deprecated benchmarks to keep the rules current and remove confusion. But for users who want to refer to rules for old benchmarks, it could be hard to find such rules. 

So this PR adds back the rules for deprecated benchmarks but use the "Latest version available" column to keep track of which MLPerf Training round a given rule was last applicable in. 