### PR TITLE
Remove the software adoption rule

### DIFF
--- a/training_rules.adoc
+++ b/training_rules.adoc
@@ -423,10 +423,6 @@ Additional exemptions need to be explicitly requested and approved in advance. I
 
 The OPEN division does not restrict mathematical equivalence.
 
-== Software Adoption ==
-
-For a given round of MLPerf, the "canonical version" of a software component shall be defined as the public version as of 14 days before submission. If the software is open source, the canonical version shall be the one compiled with the default compilation options. If a system software provider submits with a component whose version is other than the canonical version, then other submitters using the same component are allowed to update their submission to use that version.  Those other submitters must resubmit with the updated system software before the resubmission deadline during the review period. Software adoption applies only to system software, only to the version used by the software provider’s submission, and explicitly does not cover benchmark implementations. Benchmark implementations should be borrowed as a whole only if the software provider’s submission introduces new APIs.
-
 [#section-run-results]
 == Run Results
 A run result consists of a wall-clock timing measurement for a contiguous period that includes model initialization in excess of a maximum initialization time, any data preprocessing required to be on the clock, using the dataset to train the model, and quality evaluation unless specified otherwise for the benchmark.


### PR DESCRIPTION
This rule has been discussed time and again because it was added a long time ago to help Fujitsu who didn’t get the latest software from NVIDIA whereas others did. So Fujitsu wanted to borrow the software as a whole and submit during the review period for fairness. 

Since then, this rule was added but it was never enforced. Every other time someone has tried using this rule, it’s been for a weird case of trying to borrow parameters than don’t fall under the HP borrowing rule and these requests have caused a lot of churn during the review period. Most importantly, the software adoption rule has never been used successfully after it was created. 

Thus, the training WG has decided to delete the software adoption rule in June 2025.