### PR TITLE
Add rule for result resubmission

### DIFF
--- a/training_rules.adoc
+++ b/training_rules.adoc
@@ -425,13 +425,7 @@ The OPEN division does not restrict mathematical equivalence.
 
 == Results Resubmission
 
-Submitters may resubmit logs from a previous round in a future round if those logs represent their best result and they wish to showcase it. Log resubmission is permitted only when the following criteria match between both rounds:
-* Benchmark
-* Accelerator
-* Category
-* Availability
-* Software
-* Division
+Submitters may resubmit logs from a previous round in a future round if those logs represent their best result and they wish to showcase it. Log resubmission is permitted only if the system.json matches exactly between both rounds and the resubmitted logs pass the package_checker with the future round's mlperf_logging tag.
 
 Submitters must notify the review committee of their intent to resubmit logs by creating an issue in the submission repository before the first review meeting. The review committee will verify the validity of the resubmission before approval. Late notifications may result in rejection of the resubmission request.
 

--- a/training_rules.adoc
+++ b/training_rules.adoc
@@ -423,6 +423,18 @@ Additional exemptions need to be explicitly requested and approved in advance. I
 
 The OPEN division does not restrict mathematical equivalence.
 
+== Results Resubmission
+
+Submitters may resubmit logs from a previous round in a future round if those logs represent their best result and they wish to showcase it. Log resubmission is permitted only when the following criteria match between both rounds:
+* Benchmark
+* Accelerator
+* Category
+* Availability
+* Software
+* Division
+
+Submitters must notify the review committee of their intent to resubmit logs by creating an issue in the submission repository before the first review meeting. The review committee will verify the validity of the resubmission before approval. Late notifications may result in rejection of the resubmission request.
+
 [#section-run-results]
 == Run Results
 A run result consists of a wall-clock timing measurement for a contiguous period that includes model initialization in excess of a maximum initialization time, any data preprocessing required to be on the clock, using the dataset to train the model, and quality evaluation unless specified otherwise for the benchmark.


### PR DESCRIPTION
Training WG meeting notes June 5th 2025 - _Generally, submitters resubmit logs from a previous round in a future round if it is the best result they have and they want to showcase it. Add this to the training_rules to state that this is “permitted”. Additionally, in v5.0 a submission went from preview to available and the logs were resubmitted. So we need a rule to list out what criteria is ok/not ok for log resubmission. Generally, as long as benchmark, accelerators, category, availability, software, division match - it can be allowed._ 
