### PR TITLE
Require lowest precision, parallelism, MBS, and config_filename logging from v6.1

### DIFF
--- a/training_rules.adoc
+++ b/training_rules.adoc
@@ -204,6 +204,23 @@ Reference Convergence Points must be obtained using FP32 precision, FP32 emulati
 
 OPEN: Any format and scaling may be used.
 
+=== Lowest precision and parallelism logging
+From v6.1 onwards, every result log in both the Closed and Open divisions must report lowest numerical precision and parallelism through https://github.com/mlcommons/logging/tree/master/mlperf_logging/mllog[`mllog`]. Values reported by any other method are discarded.
+
+The following keys must appear exactly once in each result log:
+
+* `lowest_numerical_precision_in_linear`: lowest numerical precision used in linear / GEMM compute
+* `lowest_numerical_precision_in_attn`: lowest numerical precision used in attention compute
+* `lowest_numerical_precision_in_comm`: lowest numerical precision used in communication, for example parameter gather or all-gather
+* `tensor_parallelism`
+* `pipeline_parallelism`
+* `context_parallelism`
+* `expert_parallelism`
+
+Precision values must be one of the pre-approved numerical formats listed in <<Numerical formats>> unless the working group has approved an additional format. Parallelism values must be positive integers. Unused parallelism dimensions must be logged as `1`.
+
+Unsatisfying any of the above requirements will result in compliance checker failures reported by the https://github.com/mlcommons/logging/tree/master/mlperf_logging/package_checker[package checker].
+
 === Epoch numbering
 Epochs should always be numbered from 1.
 

--- a/training_rules.adoc
+++ b/training_rules.adoc
@@ -205,7 +205,7 @@ Reference Convergence Points must be obtained using FP32 precision, FP32 emulati
 OPEN: Any format and scaling may be used.
 
 === Lowest precision, parallelism, and run-config logging
-From v6.1 onwards, every result log in both the Closed and Open divisions must report lowest numerical precision, parallelism, micro-batch size, and the config filename through https://github.com/mlcommons/logging/tree/master/mlperf_logging/mllog[`mllog`]. Values reported by any other method are discarded.
+From v6.1 onwards, every result log in both the Closed and Open divisions must report lowest numerical precision, parallelism, micro-batch size, and the config filename through https://github.com/mlcommons/logging/tree/master/mlperf_logging/mllog[`mllog`].
 
 The following keys must appear exactly once in each result log:
 
@@ -220,8 +220,6 @@ The following keys must appear exactly once in each result log:
 * `config_filename`: the configuration file used for the run, named so that it can be matched to the submitted config
 
 Precision values must be one of the pre-approved numerical formats listed in <<Numerical formats>> unless the working group has approved an additional format. Parallelism and `micro_batch_size` values must be positive integers. Unused parallelism dimensions must be logged as `1`. `config_filename` must be a non-empty string.
-
-Unsatisfying any of the above requirements will result in compliance checker failures reported by the https://github.com/mlcommons/logging/tree/master/mlperf_logging/package_checker[package checker].
 
 === Epoch numbering
 Epochs should always be numbered from 1.

--- a/training_rules.adoc
+++ b/training_rules.adoc
@@ -204,8 +204,8 @@ Reference Convergence Points must be obtained using FP32 precision, FP32 emulati
 
 OPEN: Any format and scaling may be used.
 
-=== Lowest precision and parallelism logging
-From v6.1 onwards, every result log in both the Closed and Open divisions must report lowest numerical precision and parallelism through https://github.com/mlcommons/logging/tree/master/mlperf_logging/mllog[`mllog`]. Values reported by any other method are discarded.
+=== Lowest precision, parallelism, and run-config logging
+From v6.1 onwards, every result log in both the Closed and Open divisions must report lowest numerical precision, parallelism, micro-batch size, and the config filename through https://github.com/mlcommons/logging/tree/master/mlperf_logging/mllog[`mllog`]. Values reported by any other method are discarded.
 
 The following keys must appear exactly once in each result log:
 
@@ -216,8 +216,10 @@ The following keys must appear exactly once in each result log:
 * `pipeline_parallelism`
 * `context_parallelism`
 * `expert_parallelism`
+* `micro_batch_size`
+* `config_filename`: the configuration file used for the run, named so that it can be matched to the submitted config
 
-Precision values must be one of the pre-approved numerical formats listed in <<Numerical formats>> unless the working group has approved an additional format. Parallelism values must be positive integers. Unused parallelism dimensions must be logged as `1`.
+Precision values must be one of the pre-approved numerical formats listed in <<Numerical formats>> unless the working group has approved an additional format. Parallelism and `micro_batch_size` values must be positive integers. Unused parallelism dimensions must be logged as `1`. `config_filename` must be a non-empty string.
 
 Unsatisfying any of the above requirements will result in compliance checker failures reported by the https://github.com/mlcommons/logging/tree/master/mlperf_logging/package_checker[package checker].
 


### PR DESCRIPTION
## Summary
- Require every Closed and Open v6.1 result log to report lowest numerical precision (linear / attention / communication), parallelism (TP / PP / CP / EP), `micro_batch_size`, and `config_filename` through `mllog`.
- Specify that unused parallelism dimensions must be logged as `1`, `micro_batch_size` must be a positive integer, and `config_filename` must identify the matching submitted config.
- This makes the v6.0 optional disclosure keys mandatory, addressing https://github.com/mlcommons/training/issues/878.

Companion checker PR: https://github.com/mlcommons/logging/pull/472

Related: this is the policy counterpart to the disclosure requested in https://github.com/mlcommons/training_policies/pull/582, using the existing MLLOG key names so the result files themselves carry the information.

## Test plan
- [x] Review the new `Lowest precision, parallelism, and run-config logging` section against the v6.1 checker keys in https://github.com/mlcommons/logging/pull/472
- [x] Confirm the requirement applies to both Closed and Open, and only from v6.1 onwards
- [ ] Confirm unused parallelism `= 1` is explicit enough for non-MoE / non-LLM benchmarks
- [x] Confirm `config_filename` is required to match the submitted config